### PR TITLE
Made index only show the summary and updated title

### DIFF
--- a/app/Resources/views/index.html.twig
+++ b/app/Resources/views/index.html.twig
@@ -13,6 +13,25 @@
 
 {% block content %}
     {% for blog in blogs %}
-        {% include 'article.html.twig' with {blog : blog, comments: false} only %}
+        <article class="uk-article">
+            <h1 class="uk-article-title"><a href="{{ path("app.post", { name : blog.slug }) }}">{{ blog.title }}</a></h1>
+            <p class="uk-article-meta">
+                Written by <img class="uk-border-circle" src="{{ blog.author.gravatarUrl(20) }}"> <a href="{{ path("app.author", { name : blog.author.shortname | lower }) }}">{{ blog.author.name }}</a> on {{ blog.date | date('F jS Y') }}.
+            </p>
+
+            {{ blog.summary | markdown }}
+
+            <div class="uk-grid">
+                <div class="uk-width-1-2">
+                    <a href="{{ path("app.post", { name : blog.slug }) }}">Read whole post</a>
+                </div>
+                <div class="uk-width-1-2 uk-text-right">
+                    <i class="uk-icon uk-icon-comment"></i>
+                    <a href="{{ path("app.post", { name: blog.slug }) }}#disqus_thread">First article</a>
+                </div>
+            </div>
+            <hr>
+        </article>
+
     {% endfor %}
 {% endblock %}

--- a/app/Resources/views/layout.html.twig
+++ b/app/Resources/views/layout.html.twig
@@ -3,7 +3,8 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{% block title %}Dev Blog{% endblock %}</title>
+        <meta name="description" content="Development blog of Yannick de Lange and Iltar van der Berg" />
+        <title>{% block title %}Stovepipe Systems{% endblock %}</title>
         <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" href="/css/uikit.min.css">
         <link rel="stylesheet" href="/css/prism.css" data-noprefix />


### PR DESCRIPTION
This pull will only show the summary on the index. This will make it easier to browse the full list of blog posts and will make it easier to find what you are looking for.
